### PR TITLE
use https when making requests to espn api

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -5,7 +5,7 @@ import Boxscore from '../boxscore/boxscore';
 import FreeAgentPlayer from '../free-agent-player/free-agent-player';
 import Team from '../team/team';
 
-axios.defaults.baseURL = 'http://fantasy.espn.com/apis/v3/games/ffl/seasons/';
+axios.defaults.baseURL = 'https://fantasy.espn.com/apis/v3/games/ffl/seasons/';
 
 class Client {
   constructor(options = {}) {


### PR DESCRIPTION
The auth cookies are currently sent unencrypted to the ESPN API. This will send them over https to avoid session hijacking.