### PR TITLE
added getHistoricalTeamsAtWeek

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1747,9 +1747,9 @@
       "dev": true
     },
     "@types/prettier": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.0.tgz",
-      "integrity": "sha512-hiYA88aHiEIgDmeKlsyVsuQdcFn3Z2VuFd/Xm/HCnGnPD8UFU5BM128uzzRVVGEzKDKYUrRsRH9S2o+NUy/3IA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.1.tgz",
+      "integrity": "sha512-2zs+O+UkDsJ1Vcp667pd3f8xearMdopz/z54i99wtRDI5KLmngk7vlrYZD0ZjKHaROR03EznlBbVY9PfAEyJIQ==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -2033,9 +2033,9 @@
       "dev": true
     },
     "abab": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.4.tgz",
-      "integrity": "sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
     "acorn": {
@@ -3326,9 +3326,9 @@
       "dev": true
     },
     "decimal.js": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
-      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
       "dev": true
     },
     "decode-uri-component": {
@@ -10661,9 +10661,9 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-PcVnO6NiewhkmzV0qn7A+UZ9Xx4maNTI+O+TShmfE4pqjoCMwUMjkvoNhNHPTvgR7QH9Xt3R13iHuWy2sToFxQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.3.0.tgz",
+      "integrity": "sha512-BQRf/ej5Rp3+n7k0grQXZj9a1cHtsp4lqj01p59xBWFKdezR8sO37XnpafwNqiFac/v2Il12EIMjX/Y4VZtT8Q==",
       "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint-plugin-jest": "^24.0.0",
     "eslint-plugin-jsdoc": "^30.4.0",
     "http-server": "^0.12.3",
-    "jest": "26.4.2",
+    "jest": "^26.4.2",
     "jsdoc": "^3.6.5",
     "q": "^1.5.1",
     "webpack": "^4.44.1",

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -146,7 +146,35 @@ class Client {
       ));
     });
   }
+  
+  /**
+   * Returns an array of Team object representing each fantasy football team in the FF league.
+   *
+   * @param  {object} options Required options object.
+   * @param  {number} options.seasonId The season to grab data from.  This value must be before 2018
+   * @param  {number} options.scoringPeriodId The scoring period in which to grab teams from.
+   * @returns {Team[]} The list of teams.
+   */
+  getHistoricalTeamsAtWeek({ seasonId, scoringPeriodId }) {
+    const route = this.constructor._buildRoute({
+      base: `${this.leagueId}`,
+      params: `?scoringPeriodId=${scoringPeriodId}&seasonId=${seasonId}` +
+        '&view=mMatchupScore&view=mScoreboard&view=mSettings&view=mTopPerformers&view=mTeam'
+    });
 
+    const axiosConfig = this._buildAxiosConfig({
+      baseURL: 'https://fantasy.espn.com/apis/v3/games/ffl/leagueHistory/'
+    });
+	
+	return axios.get(route, axiosConfig).then((response) => {
+      const data = _.get(response.data, 'teams');
+      return _.map(data, (team) => (
+        Team.buildFromServer(team, { leagueId: this.leagueId, seasonId })
+      ));
+    });
+	
+  }
+  
   /**
    * Returns all NFL games that occur in the passed timeframe. NOTE: Date format must be "YYYYMMDD".
    *


### PR DESCRIPTION
When using the Client.getTeamsAtWeek() function for league stats prior to 2018, the api fails with a 404.

(node:24828) UnhandledPromiseRejectionWarning: Error: Request failed with status code 404
at createError (C:\scratch\GitHub\GentlemensLeague\node_modules\espn-fantasy-football-api\node-dev.js:1014:15)
at settle (C:\scratch\GitHub\GentlemensLeague\node_modules\espn-fantasy-football-api\node-dev.js:1289:12)
at IncomingMessage.handleStreamEnd (C:\scratch\GitHub\GentlemensLeague\node_modules\espn-fantasy-football-api\node-dev.js:361:11)
at IncomingMessage.emit (events.js:327:22)
at endReadableNT (_stream_readable.js:1220:12)
at processTicksAndRejections (internal/process/task_queues.js:84:21)
(node:24828) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag --unhandled-rejections=strict (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
(node:24828) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

I've found that I can get the relevent Teams map by utilizing the same endpoint as the getHistoricalScoreboardForWeek() api,  As a result I've added getHistoricalTeamsAtWeek() to fulfill league history for years prior to 2018.  I've confirmed that this has been able to pull information from my personal ESPN league which has data going back to the 2012 season.
