### PR TITLE
Include current team name in team.js response map

### DIFF
--- a/src/team/team.js
+++ b/src/team/team.js
@@ -43,7 +43,7 @@ class Team extends BaseCacheableObject {
    *
    * @property {number} id The id of the team in the ESPN universe.
    * @property {string} abbreviation The team's abbreviation.
-   * @property {string} currentName The current team name
+   * @property {string} teamName The current team name
    * @property {string} name The team's name.
    * @property {string} logoURL The URL for the team's uploaded logo.
    * @property {number} wavierRank The team's position in the current wavier order.
@@ -86,7 +86,7 @@ class Team extends BaseCacheableObject {
   static responseMap = {
     id: 'id',
     abbreviation: 'abbrev',
-    currentName: 'name',
+    teamName: 'name',
     name: {
       key: 'location',
       manualParse: (responseData, data) => `${_.trim(data.location)} ${_.trim(data.nickname)}`

--- a/src/team/team.js
+++ b/src/team/team.js
@@ -43,6 +43,7 @@ class Team extends BaseCacheableObject {
    *
    * @property {number} id The id of the team in the ESPN universe.
    * @property {string} abbreviation The team's abbreviation.
+   * @property {string} currentName The current team name
    * @property {string} name The team's name.
    * @property {string} logoURL The URL for the team's uploaded logo.
    * @property {number} wavierRank The team's position in the current wavier order.
@@ -85,6 +86,7 @@ class Team extends BaseCacheableObject {
   static responseMap = {
     id: 'id',
     abbreviation: 'abbrev',
+    currentName: 'name',
     name: {
       key: 'location',
       manualParse: (responseData, data) => `${_.trim(data.location)} ${_.trim(data.nickname)}`


### PR DESCRIPTION
fixes #227 by adding:

`teamName: 'name',`

raw data using URL provided in #227 with different league ID now appears as such:
In the following data, initial team name at season start was Team Cruise, however the user changed their team name later to Backyard Brews.
Current Team name is desired per issue.

....
 "teams": [
        {
            "abbrev": "Brew",
            "currentProjectedRank": 5,
            "divisionId": 0,
            "draftDayProjectedRank": 1,
            "draftStrategy": {},
            "id": 1,
            "isActive": false,
            "location": "Team",
            "logo": "https://g.espncdn.com/lm-static/logo-packs/ffl/AtTheStadium-RobbHarskamp/At_The_Stadium_16.svg",
            "logoType": "VECTOR",
            **"name": "Backyard Brews",**
            "nickname": "Cruise",
....

verified by directly modifying node-dev.js in local project