### PR TITLE
Update baseURL

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -10,7 +10,7 @@ import Team from '../team/team';
 
 import { flattenObjectSansNumericKeys } from '../utils';
 
-axios.defaults.baseURL = 'https://fantasy.espn.com/apis/v3/games/ffl/seasons/';
+axios.defaults.baseURL = 'https://lm-api-reads.fantasy.espn.com/apis/v3/games/ffl/seasons/';
 
 /**
  * Provides functionality to make a variety of API calls to ESPN for a given fantasy football


### PR DESCRIPTION
It appears that for the 2024 season the base URL has changed.

This pull request would update the base URL. 
I believe this would also close issue #244.