### PR TITLE
Update baseURL for fantasy.espn based URLs

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -170,7 +170,7 @@ class Client {
     });
 
     const axiosConfig = this._buildAxiosConfig({
-      baseURL: 'https://fantasy.espn.com/apis/v3/games/ffl/leagueHistory/'
+      baseURL: 'https://lm-api-reads.fantasy.espn.com/apis/v3/games/ffl/leagueHistory/'
     });
     return axios.get(route, axiosConfig).then((response) => {
       const schedule = _.get(response.data[0], 'schedule'); // Data is an array instead of object
@@ -276,7 +276,7 @@ class Client {
     });
 
     const axiosConfig = this._buildAxiosConfig({
-      baseURL: 'https://fantasy.espn.com/apis/v3/games/ffl/leagueHistory/'
+      baseURL: 'https://lm-api-reads.fantasy.espn.com/apis/v3/games/ffl/leagueHistory/'
     });
 
     return axios.get(route, axiosConfig).then((response) => (

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -10,7 +10,7 @@ import Team from '../team/team';
 
 import { flattenObjectSansNumericKeys } from '../utils';
 
-axios.defaults.baseURL = 'https://fantasy.espn.com/apis/v3/games/ffl/seasons/';
+axios.defaults.baseURL = 'https://lm-api-reads.fantasy.espn.com/apis/v3/games/ffl/seasons/';
 
 /**
  * Provides functionality to make a variety of API calls to ESPN for a given fantasy football


### PR DESCRIPTION
Correction to previous, now closed pull request #245 .

#245 only modified line 13
```javascript
13 | axios.defaults.baseURL = 'https://......
``` 
 not realizing there existed the url existed on line 173 and 279
```javascript
173 | baseURL: 'https://......
279 | baseURL: 'https://......
``` 

there is no change to the base URL for getNFLGamesForPeriod.
```javascript
317 | ...... ({ baseURL: 'https://site.api.espn.com/' });
``` 

run test:integration no longer reports failed Tests locally, so I'm cautiously optimistic.